### PR TITLE
Fix typo: remove stray 't' in heatmap_utils.py line 140

### DIFF
--- a/vis_scripts/vis_utils/heatmap_utils.py
+++ b/vis_scripts/vis_utils/heatmap_utils.py
@@ -137,7 +137,7 @@ def compute_from_patches(wsi_object, feature_extractor_name=None, feature_extrac
         coords = coords.numpy()
         
         with torch.inference_mode():
-            features = feature_extractor_adapter(feature_extractor, roi, feature_extractor_name)t
+            features = feature_extractor_adapter(feature_extractor, roi, feature_extractor_name)
             if len(features.shape) == 3:
                 features = features.squeeze(0)
 


### PR DESCRIPTION
### Summary
This PR fixes a small typo in `vis_scripts/vis_utils/heatmap_utils.py` at line 140,
where an extra trailing character 't' causes a syntax error during visualization.

### Changes
- Removed the stray 't' at the end of the line.
- Verified the script runs without syntax errors after the change.

### Motivation
The typo prevents the visualization module from running properly.
This fix ensures compatibility and smooth execution of the visualization scripts.

### Checklist
- [x] Code compiles and runs without errors
- [x] Only minimal, necessary change applied
- [x] Verified fix locally in VS Code

Thank you for maintaining this great MIL_BASELINE project!
