### PR TITLE
Add nnMIL classification integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ fix bug of all MIL-models expect DTFD-MIL
 * MEAN_MIL
 * MAX_MIL
 * AB_MIL [Attention-based Deep Multiple Instance Learning](https://arxiv.org/abs/1802.04712) (ICML 2018)
+* NN_MIL [nnMIL: a generalizable multiple instance learning framework for computational pathology](https://www.nature.com/articles/s41551-026-01767-8) (Nature Biomedical Engineering 2026)
 * MIXUP_MIL [mixup: Beyond Empirical Risk Minimization](https://arxiv.org/abs/1710.09412) (ICLR 2018)
 * DT_MIL [Deformable Transformer for Multi-instance Learning on Histopathological Image](https://link.springer.com/chapter/10.1007/978-3-030-87237-3_20) (MICCAI 2021)
 * TRANS_MIL [Transformer based Correlated Multiple Instance Learning for WSI Classification](https://arxiv.org/abs/2106.00908) (NeurIPS 2021)
@@ -172,6 +173,9 @@ You can use the dataset-split-scripts to perform different dataset-split, the de
 ### :fire: **Train/Test MIL**
 #### **Yaml Config**
 You can config the yaml-file in `/configs`. For example, `/configs/AB_MIL.yaml`, A detailed explanation has been written in  `/configs/AB_MIL.yaml`. 
+
+#### **NN_MIL (nnMIL)**
+`configs/NN_MIL.yaml` adds the classification workflow from [nnMIL](https://github.com/Luoxd1996/nnMIL): fixed-length patch sub-bags for batched training, class-balanced mini-batches, random feature-subspace attention, and deterministic overlapping-subspace ensemble inference. Set `Model.fixed_bag_size: auto` to use half the median training patch count, or provide an explicit positive integer. During evaluation, `test_mil.py` writes `NN_MIL_predictions.csv` alongside standard metrics; it includes per-class probabilities, entropy, mutual information, probability variance and the number of subspaces. Padding is masked before attention softmax and therefore never contributes to slide aggregation.
 #### **Train & Test**
 Then, `/train_mil.py` will help you like this:
 ``` shell

--- a/configs/NN_MIL.yaml
+++ b/configs/NN_MIL.yaml
@@ -1,0 +1,58 @@
+General:
+    MODEL_NAME: NN_MIL
+    seed: 2024
+    num_classes: 2
+    num_epochs: 50
+    device: 0
+    num_workers: 4
+    best_model_metric: macro_auc
+    earlystop:
+        use: False
+        patience: 10
+        metric: macro_auc
+
+Dataset:
+    DATASET_NAME: your_dataset_name
+    dataset_csv_path: /path/to/your/dataset.csv
+
+Logs:
+    log_root_dir: /path/to/your/log_dir/
+
+Model:
+    # Set to 'auto' to use floor(0.5 * median training patch count), as nnMIL does.
+    fixed_bag_size: auto
+    auto_bag_size_factor: 0.5
+    batch_size: 32
+    task_aware_sampler: True
+    in_dim: 1024
+    hidden_dim: 256
+    dropout: 0.25
+    activation: softmax
+    feature_select: True
+    # Evaluation uses overlapping hidden_dim-wide windows with stride hidden_dim / divisor.
+    eval_stride_divisor: 4
+    cover_shuffle: True
+    cover_seed: 42
+    criterion: ce
+    optimizer:
+        which: adamw
+        adam_config:
+            lr: 0.0003
+            weight_decay: 0.00001
+        adamw_config:
+            lr: 0.0003
+            weight_decay: 0.01
+    scheduler:
+        warmup: 5
+        which: cosine
+        step_config:
+            step_size: 20
+            gamma: 0.9
+        multi_step_config:
+            milestones: [20, 30, 40]
+            gamma: 0.9
+        exponential_config:
+            gamma: 0.9
+        cosine_config:
+            T_max: 50
+            eta_min: 0.000001

--- a/modules/NN_MIL/__init__.py
+++ b/modules/NN_MIL/__init__.py
@@ -1,0 +1,3 @@
+from .nn_mil import NN_MIL
+
+__all__ = ["NN_MIL"]

--- a/modules/NN_MIL/nn_mil.py
+++ b/modules/NN_MIL/nn_mil.py
@@ -1,0 +1,135 @@
+"""nnMIL attention aggregator for MIL_BASELINE classification workflows."""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class NN_MIL(nn.Module):
+    """Attention MIL with random feature subspaces and subspace ensembles.
+
+    Attention is calculated in an ``hidden_dim``-wide feature subspace, while
+    the weighted bag representation remains in the original embedding space.
+    ``valid_mask`` prevents zero-padded patches from participating in the
+    attention softmax.
+    """
+
+    def __init__(self, in_dim, hidden_dim=256, num_classes=2, dropout=0.25,
+                 activation="softmax", feature_select=True,
+                 eval_stride_divisor=4, cover_shuffle=True, cover_seed=42):
+        super().__init__()
+        if in_dim < 1 or hidden_dim < 1:
+            raise ValueError("in_dim and hidden_dim must be positive")
+        if eval_stride_divisor < 1:
+            raise ValueError("eval_stride_divisor must be at least 1")
+        self.in_dim = int(in_dim)
+        self.hidden_dim = int(hidden_dim)
+        self.num_classes = int(num_classes)
+        self.feature_select = bool(feature_select)
+        self.eval_stride_divisor = int(eval_stride_divisor)
+        self.cover_shuffle = bool(cover_shuffle)
+        self.cover_seed = int(cover_seed)
+        self.activation = activation
+        self.V = nn.Linear(self.in_dim, self.hidden_dim)
+        self.U = nn.Linear(self.in_dim, self.hidden_dim)
+        self.w = nn.Linear(self.hidden_dim, 1)
+        self.dropout = nn.Dropout(float(dropout)) if dropout else nn.Identity()
+        self.classifier = nn.Linear(self.in_dim, self.num_classes)
+
+    def _activate(self, scores):
+        if self.activation != "softmax":
+            raise ValueError("NN_MIL currently requires activation='softmax'")
+        return F.softmax(scores, dim=1)
+
+    @staticmethod
+    def _linear_subspace(layer, x, indices):
+        return F.linear(x.index_select(-1, indices), layer.weight.index_select(1, indices), layer.bias)
+
+    def _attention(self, x, valid_mask=None, indices=None):
+        if indices is None:
+            a, b = torch.tanh(self.V(x)), torch.sigmoid(self.U(x))
+        else:
+            a = torch.tanh(self._linear_subspace(self.V, x, indices))
+            b = torch.sigmoid(self._linear_subspace(self.U, x, indices))
+        scores = self.w(self.dropout(a) * self.dropout(b))
+        if valid_mask is not None:
+            if valid_mask.shape != x.shape[:2]:
+                raise ValueError("valid_mask must have shape [batch, patches]")
+            scores = scores.masked_fill(~valid_mask.unsqueeze(-1), float("-inf"))
+        return self._activate(scores)
+
+    def _cover_indices(self, device):
+        keep = min(self.hidden_dim, self.in_dim)
+        if keep >= self.in_dim:
+            return [torch.arange(self.in_dim, device=device)]
+        if self.cover_shuffle:
+            generator = torch.Generator(device=device)
+            generator.manual_seed(self.cover_seed)
+            permutation = torch.randperm(self.in_dim, generator=generator, device=device)
+        else:
+            permutation = torch.arange(self.in_dim, device=device)
+        stride = max(1, keep // self.eval_stride_divisor)
+        starts = list(range(0, self.in_dim - keep + 1, stride))
+        if starts[-1] != self.in_dim - keep:
+            starts.append(self.in_dim - keep)
+        return [permutation[start:start + keep] for start in starts]
+
+    @staticmethod
+    def _entropy(probabilities):
+        return -(probabilities * torch.log(probabilities.clamp_min(1e-8))).sum(dim=-1)
+
+    def forward(self, x, valid_mask=None, return_WSI_attn=False, return_WSI_feature=False):
+        if x.ndim == 2:
+            x = x.unsqueeze(0)
+        if x.ndim != 3 or x.shape[-1] != self.in_dim:
+            raise ValueError(f"Expected [batch, patches, {self.in_dim}], received {tuple(x.shape)}")
+        if valid_mask is None:
+            valid_mask = torch.ones(x.shape[:2], device=x.device, dtype=torch.bool)
+        else:
+            valid_mask = valid_mask.to(device=x.device, dtype=torch.bool)
+        if not valid_mask.any(dim=1).all():
+            raise ValueError("Each bag must contain at least one valid patch")
+
+        keep = min(self.hidden_dim, self.in_dim)
+        if self.training:
+            indices = None
+            if self.feature_select and keep < self.in_dim:
+                indices = torch.randperm(self.in_dim, device=x.device)[:keep]
+            attention = self._attention(x, valid_mask, indices)
+            feature = torch.bmm(attention.transpose(1, 2), x).squeeze(1)
+            result = {"logits": self.classifier(feature)}
+            if return_WSI_attn:
+                result["WSI_attn"] = attention.squeeze(-1)
+            if return_WSI_feature:
+                result["WSI_feature"] = feature
+            return result
+
+        chunks = [None] if not self.feature_select else self._cover_indices(x.device)
+        logits_per_chunk, features_per_chunk, attentions_per_chunk = [], [], []
+        for indices in chunks:
+            attention = self._attention(x, valid_mask, indices)
+            feature = torch.bmm(attention.transpose(1, 2), x).squeeze(1)
+            logits_per_chunk.append(self.classifier(feature))
+            features_per_chunk.append(feature)
+            attentions_per_chunk.append(attention.squeeze(-1))
+        chunk_logits = torch.stack(logits_per_chunk, dim=0)
+        chunk_probabilities = F.softmax(chunk_logits, dim=-1)
+        mean_probabilities = chunk_probabilities.mean(dim=0)
+        total_entropy = self._entropy(mean_probabilities)
+        entropy_each = self._entropy(chunk_probabilities)
+        aleatoric_entropy = entropy_each.mean(dim=0)
+        result = {
+            "logits": chunk_logits.mean(dim=0),
+            "chunk_logits": chunk_logits,
+            "chunk_probabilities": chunk_probabilities,
+            "total_entropy": total_entropy,
+            "aleatoric_entropy": aleatoric_entropy,
+            "mutual_information": (total_entropy - aleatoric_entropy).clamp_min(0),
+            "probability_variance": chunk_probabilities.var(dim=0, unbiased=False),
+        }
+        if return_WSI_feature:
+            result["WSI_feature"] = torch.stack(features_per_chunk, dim=0).mean(dim=0)
+        if return_WSI_attn:
+            result["WSI_attn"] = torch.stack(attentions_per_chunk, dim=0).mean(dim=0)
+            result["WSI_attn_std"] = torch.stack(attentions_per_chunk, dim=0).std(dim=0, unbiased=False)
+        return result

--- a/process/NN_MIL/__init__.py
+++ b/process/NN_MIL/__init__.py
@@ -1,0 +1,3 @@
+from .process_nn_mil import process_NN_MIL
+
+__all__ = ["process_NN_MIL"]

--- a/process/NN_MIL/process_nn_mil.py
+++ b/process/NN_MIL/process_nn_mil.py
@@ -1,0 +1,88 @@
+"""Classification training pipeline for nnMIL in MIL_BASELINE."""
+
+from functools import partial
+
+import torch
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+from modules.NN_MIL.nn_mil import NN_MIL
+from utils.general_utils import add_epoch_info_log, early_stop, init_epoch_info_log, set_global_seed
+from utils.model_utils import get_criterion, get_optimizer, get_scheduler, model_select, save_last_model, save_log
+from utils.nnmil_utils import BalancedBatchSampler, fixed_bag_collate, nnmil_train_loop, nnmil_val_loop, resolve_fixed_bag_size
+from utils.process_utils import get_process_pipeline
+from utils.wsi_utils import WSI_Dataset
+
+
+def process_NN_MIL(args):
+    train_dataset = WSI_Dataset(args.Dataset.dataset_csv_path, "train")
+    val_dataset = WSI_Dataset(args.Dataset.dataset_csv_path, "val")
+    test_dataset = WSI_Dataset(args.Dataset.dataset_csv_path, "test")
+    process_pipeline = get_process_pipeline(val_dataset, test_dataset)
+    args.General.process_pipeline = process_pipeline
+    set_global_seed(args.General.seed)
+
+    model_config = args.Model
+    fixed_bag_size, observed_lengths = resolve_fixed_bag_size(
+        train_dataset, getattr(model_config, "fixed_bag_size", "auto"),
+        getattr(model_config, "auto_bag_size_factor", 0.5),
+    )
+    if observed_lengths is not None:
+        print(f"NN_MIL resolved fixed_bag_size={fixed_bag_size} from train median={torch.tensor(observed_lengths).median().item():.0f}")
+    else:
+        print(f"NN_MIL using configured fixed_bag_size={fixed_bag_size}")
+
+    batch_size = int(getattr(model_config, "batch_size", 32))
+    collate_fn = partial(fixed_bag_collate, bag_size=fixed_bag_size)
+    balanced = bool(getattr(model_config, "task_aware_sampler", True))
+    if balanced:
+        sampler = BalancedBatchSampler(train_dataset.labels_list, batch_size, seed=args.General.seed)
+        train_loader = DataLoader(train_dataset, batch_sampler=sampler, num_workers=args.General.num_workers, collate_fn=collate_fn)
+        print("NN_MIL training with class-balanced mini-batches")
+    else:
+        generator = torch.Generator().manual_seed(args.General.seed)
+        train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, generator=generator,
+                                  num_workers=args.General.num_workers, collate_fn=collate_fn)
+        print("NN_MIL training with randomly shuffled mini-batches")
+    val_loader = DataLoader(val_dataset, batch_size=1, shuffle=False, num_workers=args.General.num_workers)
+    test_loader = DataLoader(test_dataset, batch_size=1, shuffle=False, num_workers=args.General.num_workers)
+
+    device = torch.device(f"cuda:{args.General.device}" if torch.cuda.is_available() else "cpu")
+    model = NN_MIL(
+        in_dim=model_config.in_dim, hidden_dim=getattr(model_config, "hidden_dim", 256),
+        num_classes=args.General.num_classes, dropout=getattr(model_config, "dropout", 0.25),
+        activation=getattr(model_config, "activation", "softmax"),
+        feature_select=getattr(model_config, "feature_select", True),
+        eval_stride_divisor=getattr(model_config, "eval_stride_divisor", 4),
+        cover_shuffle=getattr(model_config, "cover_shuffle", True),
+        cover_seed=getattr(model_config, "cover_seed", 42),
+    ).to(device)
+    print(f"NN_MIL model ready ({sum(parameter.numel() for parameter in model.parameters()):,} parameters) on {device}")
+    optimizer, base_lr = get_optimizer(args, model)
+    scheduler, warmup_scheduler = get_scheduler(args, optimizer, base_lr)
+    criterion = get_criterion(model_config.criterion)
+    warmup_epoch = model_config.scheduler.warmup
+
+    epoch_info_log = init_epoch_info_log()
+    best_metric = 9999 if args.General.best_model_metric == "val_loss" else 0
+    reverse = args.General.best_model_metric == "val_loss"
+    best_epoch = 1
+    for epoch in tqdm(range(args.General.num_epochs), colour="GREEN"):
+        active_scheduler = warmup_scheduler if epoch + 1 <= warmup_epoch else scheduler
+        train_loss = nnmil_train_loop(device, model, train_loader, criterion, optimizer, active_scheduler)
+        val_loss = val_metrics = test_loss = test_metrics = None
+        if process_pipeline in ["Train_Val_Test", "Train_Val"]:
+            val_loss, val_metrics = nnmil_val_loop(device, args.General.num_classes, model, val_loader, criterion)
+        if process_pipeline == "Train_Val_Test":
+            test_loss, test_metrics = nnmil_val_loop(device, args.General.num_classes, model, test_loader, criterion)
+        elif process_pipeline == "Train_Test" and epoch + 1 == args.General.num_epochs:
+            test_loss, test_metrics = nnmil_val_loop(device, args.General.num_classes, model, test_loader, criterion)
+        print(f"NN_MIL epoch {epoch + 1}: train_loss={train_loss:.6f}, val_loss={val_loss}, test_loss={test_loss}")
+        add_epoch_info_log(epoch_info_log, epoch, train_loss, val_loss, test_loss, val_metrics, test_metrics)
+        best_metric, best_epoch = model_select(reverse, args, model.state_dict(), val_metrics,
+                                                args.General.best_model_metric, best_metric, epoch, best_epoch)
+        if early_stop(args, epoch_info_log, process_pipeline, epoch, model.state_dict(), best_epoch):
+            break
+        if epoch + 1 == args.General.num_epochs:
+            save_last_model(args, model.state_dict(), epoch + 1)
+            save_log(args, epoch_info_log, best_epoch, process_pipeline)

--- a/process/process_all.py
+++ b/process/process_all.py
@@ -13,6 +13,9 @@ def process(args,yaml_path,options):
     elif args.General.MODEL_NAME == 'AB_MIL':
         from .AB_MIL.process_ab_mil import process_AB_MIL
         process_AB_MIL(args)
+    elif args.General.MODEL_NAME == 'NN_MIL':
+        from .NN_MIL.process_nn_mil import process_NN_MIL
+        process_NN_MIL(args)
     elif args.General.MODEL_NAME == 'MO_MIL':
         from .MO_MIL.process_mo_mil import process_MO_MIL
         process_MO_MIL(args)

--- a/test_mil.py
+++ b/test_mil.py
@@ -8,6 +8,7 @@ import torch
 import shutil
 import os
 from utils.model_utils import get_model_from_yaml,get_criterion
+from utils.nnmil_utils import nnmil_val_loop
 warnings.filterwarnings('ignore')
 
 def test(args):
@@ -58,6 +59,11 @@ def test(args):
         test_loss,test_metrics =  ds_val_loop(device,num_classes,mil_model,test_dataloader,criterion)
     elif yaml_args.General.MODEL_NAME == 'DTFD_MIL':
         test_loss,test_metrics =  dtfd_val_loop(device,num_classes,model_list,test_dataloader,criterion,yaml_args.Model.num_Group,yaml_args.Model.grad_clipping,yaml_args.Model.distill,yaml_args.Model.total_instance)
+    elif yaml_args.General.MODEL_NAME == 'NN_MIL':
+        test_loss,test_metrics,predictions = nnmil_val_loop(
+            device, num_classes, mil_model, test_dataloader, criterion,
+            return_predictions=True, slide_paths=test_ds.slide_path_list,
+        )
     else:
         test_loss,test_metrics =  val_loop(device,num_classes,mil_model,test_dataloader,criterion)
     
@@ -77,6 +83,10 @@ def test(args):
     log_to_save = {'test_loss':test_loss,'test_metrics':test_metrics}
     with open(test_log_path,'w') as f:
         f.write(str(log_to_save))
+    if model_name == 'NN_MIL':
+        prediction_path = os.path.join(test_log_dir, 'NN_MIL_predictions.csv')
+        predictions.to_csv(prediction_path, index=False)
+        print(f"NN_MIL predictions and uncertainty saved at: {prediction_path}")
     print(f"Test log saved at: {test_log_path}")
     
 

--- a/tests/test_nn_mil.py
+++ b/tests/test_nn_mil.py
@@ -1,0 +1,108 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import pandas as pd
+import torch
+import yaml
+
+from modules.NN_MIL.nn_mil import NN_MIL
+from utils.nnmil_utils import fixed_bag_collate
+
+
+class TestNNMIL(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(7)
+        self.model = NN_MIL(in_dim=8, hidden_dim=4, num_classes=3, dropout=0.0,
+                            eval_stride_divisor=2, cover_seed=11)
+
+    def test_padding_mask_matches_unpadded_evaluation(self):
+        features = torch.randn(1, 3, 8)
+        padded = torch.cat([features, torch.zeros(1, 2, 8)], dim=1)
+        mask = torch.tensor([[True, True, True, False, False]])
+        self.model.eval()
+        raw_logits = self.model(features)["logits"]
+        padded_logits = self.model(padded, valid_mask=mask)["logits"]
+        self.assertTrue(torch.allclose(raw_logits, padded_logits, atol=1e-6))
+
+    def test_training_supports_batched_fixed_bags_and_backward(self):
+        bags = torch.randn(3, 6, 8)
+        mask = torch.tensor([[True] * 6, [True] * 4 + [False] * 2, [True] * 5 + [False]])
+        self.model.train()
+        logits = self.model(bags, valid_mask=mask)["logits"]
+        self.assertEqual(tuple(logits.shape), (3, 3))
+        logits.sum().backward()
+        self.assertIsNotNone(self.model.V.weight.grad)
+
+    def test_evaluation_returns_deterministic_ensemble_uncertainty(self):
+        self.model.eval()
+        features = torch.randn(2, 5, 8)
+        first = self.model(features)
+        second = self.model(features)
+        self.assertTrue(torch.equal(first["logits"], second["logits"]))
+        self.assertGreater(first["chunk_logits"].shape[0], 1)
+        self.assertTrue(torch.all(first["mutual_information"] >= 0))
+
+    def test_fixed_bag_collate_subsamples_and_masks_padding(self):
+        long_bag = torch.randn(7, 8)
+        short_bag = torch.randn(3, 8)
+        bags, labels, mask = fixed_bag_collate([(long_bag, torch.tensor(0)), (short_bag, torch.tensor(1))], 5)
+        self.assertEqual(tuple(bags.shape), (2, 5, 8))
+        self.assertEqual(labels.tolist(), [0, 1])
+        self.assertEqual(mask.sum(dim=1).tolist(), [5, 3])
+
+    def test_train_and_test_entrypoints(self):
+        """A one-epoch end-to-end smoke test of the MIL_BASELINE integration."""
+        repository_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        with tempfile.TemporaryDirectory() as directory:
+            rows = {}
+            for split, labels in {"train": [0, 1, 0, 1], "val": [0, 1], "test": [0, 1]}.items():
+                paths = []
+                for index, label in enumerate(labels):
+                    path = os.path.join(directory, f"{split}_{index}.pt")
+                    torch.save(torch.randn(3 + index, 8), path)
+                    paths.append(path)
+                rows[f"{split}_slide_path"] = pd.Series(paths)
+                rows[f"{split}_label"] = pd.Series(labels)
+            dataset_path = os.path.join(directory, "dataset.csv")
+            pd.DataFrame(rows).to_csv(dataset_path, index=False)
+            logs = os.path.join(directory, "logs")
+            config = {
+                "General": {"MODEL_NAME": "NN_MIL", "seed": 1, "num_classes": 2, "num_epochs": 1,
+                            "device": 0, "num_workers": 0, "best_model_metric": "macro_auc",
+                            "earlystop": {"use": False, "patience": 2, "metric": "macro_auc"}},
+                "Dataset": {"DATASET_NAME": "toy", "dataset_csv_path": dataset_path, "dataset_root_dir": {}},
+                "Logs": {"log_root_dir": logs},
+                "Model": {
+                    "fixed_bag_size": 4, "auto_bag_size_factor": 0.5, "batch_size": 2,
+                    "task_aware_sampler": True, "in_dim": 8, "hidden_dim": 4, "dropout": 0.0,
+                    "activation": "softmax", "feature_select": True, "eval_stride_divisor": 2,
+                    "cover_shuffle": True, "cover_seed": 3, "criterion": "ce",
+                    "optimizer": {"which": "adam", "adam_config": {"lr": 0.001, "weight_decay": 0.0},
+                                  "adamw_config": {"lr": 0.001, "weight_decay": 0.0}},
+                    "scheduler": {"warmup": 1, "which": "none", "step_config": {"step_size": 2, "gamma": 0.9},
+                                  "multi_step_config": {"milestones": [2], "gamma": 0.9},
+                                  "exponential_config": {"gamma": 0.9}, "cosine_config": {"T_max": 2, "eta_min": 0.0}},
+                },
+            }
+            config_path = os.path.join(directory, "nn_mil.yaml")
+            with open(config_path, "w", encoding="utf-8") as stream:
+                yaml.safe_dump(config, stream)
+            subprocess.run([sys.executable, "train_mil.py", "--yaml_path", config_path], cwd=repository_root, check=True)
+            checkpoint = next(os.path.join(root, file) for root, _, files in os.walk(logs) for file in files
+                              if file.startswith("Last_EPOCH_"))
+            test_log_dir = os.path.join(directory, "test_output")
+            subprocess.run([sys.executable, "test_mil.py", "--yaml_path", config_path,
+                            "--test_dataset_csv", dataset_path, "--model_weight_path", checkpoint,
+                            "--test_log_dir", test_log_dir], cwd=repository_root, check=True)
+            prediction_path = os.path.join(test_log_dir, "NN_MIL_predictions.csv")
+            self.assertTrue(os.path.isfile(prediction_path))
+            predictions = pd.read_csv(prediction_path)
+            self.assertIn("mutual_information", predictions.columns)
+            self.assertEqual(len(predictions), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/model_utils.py
+++ b/utils/model_utils.py
@@ -140,7 +140,21 @@ def save_log(args,epoch_info_log,best_epoch,process_pipeline):
     
 def get_model_from_yaml(yaml_args):
     model_name = yaml_args.General.MODEL_NAME
-    if model_name == 'AB_MIL':
+    if model_name == 'NN_MIL':
+        from modules.NN_MIL.nn_mil import NN_MIL
+        mil_model = NN_MIL(
+            in_dim=yaml_args.Model.in_dim,
+            hidden_dim=getattr(yaml_args.Model, 'hidden_dim', 256),
+            num_classes=yaml_args.General.num_classes,
+            dropout=getattr(yaml_args.Model, 'dropout', 0.25),
+            activation=getattr(yaml_args.Model, 'activation', 'softmax'),
+            feature_select=getattr(yaml_args.Model, 'feature_select', True),
+            eval_stride_divisor=getattr(yaml_args.Model, 'eval_stride_divisor', 4),
+            cover_shuffle=getattr(yaml_args.Model, 'cover_shuffle', True),
+            cover_seed=getattr(yaml_args.Model, 'cover_seed', 42),
+        )
+        return mil_model
+    elif model_name == 'AB_MIL':
         from modules.AB_MIL.ab_mil import AB_MIL
         mil_model = AB_MIL(yaml_args.Model.L,yaml_args.Model.D,yaml_args.General.num_classes,yaml_args.Model.dropout,get_act(yaml_args.Model.act),yaml_args.Model.in_dim)
         return mil_model

--- a/utils/nnmil_utils.py
+++ b/utils/nnmil_utils.py
@@ -1,0 +1,150 @@
+"""Data batching, training and evaluation utilities for NN_MIL."""
+
+import math
+from collections import defaultdict
+
+import pandas as pd
+import torch
+from torch.utils.data import Sampler
+
+from .loop_utils import cal_scores
+
+
+class BalancedBatchSampler(Sampler):
+    """Yield approximately class-balanced batches, recycling a class only when needed."""
+
+    def __init__(self, labels, batch_size, seed=2024):
+        if batch_size < 1:
+            raise ValueError("batch_size must be positive")
+        self.labels = [int(label) for label in labels]
+        self.batch_size = int(batch_size)
+        self.seed = int(seed)
+        self.class_indices = defaultdict(list)
+        for index, label in enumerate(self.labels):
+            self.class_indices[label].append(index)
+        if len(self.class_indices) < 2:
+            raise ValueError("BalancedBatchSampler requires at least two classes")
+
+    def __len__(self):
+        return math.ceil(len(self.labels) / self.batch_size)
+
+    def __iter__(self):
+        generator = torch.Generator()
+        generator.manual_seed(self.seed + torch.initial_seed() % (2 ** 31 - 1))
+        classes = sorted(self.class_indices)
+        pools = {label: torch.tensor(indices)[torch.randperm(len(indices), generator=generator)].tolist()
+                 for label, indices in self.class_indices.items()}
+        positions = {label: 0 for label in classes}
+
+        def next_index(label):
+            if positions[label] >= len(pools[label]):
+                base = torch.tensor(self.class_indices[label])
+                pools[label] = base[torch.randperm(len(base), generator=generator)].tolist()
+                positions[label] = 0
+            selected = pools[label][positions[label]]
+            positions[label] += 1
+            return selected
+
+        for batch_number in range(len(self)):
+            size = min(self.batch_size, len(self.labels) - batch_number * self.batch_size)
+            targets = [classes[position % len(classes)] for position in range(size)]
+            order = torch.randperm(size, generator=generator).tolist()
+            yield [next_index(targets[position]) for position in order]
+
+
+def resolve_fixed_bag_size(dataset, configured_size="auto", factor=0.5):
+    """Resolve paper-style M: a fraction of the train-bag median."""
+    if isinstance(configured_size, str) and configured_size.lower() == "auto":
+        lengths = [int(dataset[index][0].shape[0]) for index in range(len(dataset))]
+        if not lengths or min(lengths) < 1:
+            raise ValueError("All NN_MIL training bags must contain at least one patch")
+        median = float(torch.tensor(lengths, dtype=torch.float32).median().item())
+        return max(1, int(median * float(factor))), lengths
+    size = int(configured_size)
+    if size < 1:
+        raise ValueError("fixed_bag_size must be a positive integer or 'auto'")
+    return size, None
+
+
+def fixed_bag_collate(batch, bag_size):
+    """Randomly subsample or zero-pad feature bags and return a valid-patch mask."""
+    features, labels, masks = [], [], []
+    for feature, label in batch:
+        if feature.ndim == 3 and feature.shape[0] == 1:
+            feature = feature.squeeze(0)
+        if feature.ndim != 2:
+            raise ValueError("Each NN_MIL feature bag must have shape [patches, features]")
+        patch_count = feature.shape[0]
+        if patch_count < 1:
+            raise ValueError("NN_MIL cannot train on an empty patch bag")
+        if patch_count > bag_size:
+            selected = torch.randperm(patch_count)[:bag_size]
+            feature = feature.index_select(0, selected)
+            mask = torch.ones(bag_size, dtype=torch.bool)
+        elif patch_count < bag_size:
+            padding = torch.zeros(bag_size - patch_count, feature.shape[1], dtype=feature.dtype)
+            feature = torch.cat([feature, padding], dim=0)
+            mask = torch.zeros(bag_size, dtype=torch.bool)
+            mask[:patch_count] = True
+        else:
+            mask = torch.ones(bag_size, dtype=torch.bool)
+        features.append(feature)
+        labels.append(label)
+        masks.append(mask)
+    return torch.stack(features), torch.stack(labels).long(), torch.stack(masks)
+
+
+def nnmil_train_loop(device, model, loader, criterion, optimizer, scheduler):
+    model.train()
+    total_loss = 0.0
+    for bags, labels, valid_masks in loader:
+        bags, labels = bags.to(device).float(), labels.to(device).long()
+        valid_masks = valid_masks.to(device)
+        optimizer.zero_grad()
+        logits = model(bags, valid_mask=valid_masks)["logits"]
+        loss = criterion(logits, labels)
+        loss.backward()
+        optimizer.step()
+        total_loss += loss.item()
+    if scheduler is not None:
+        scheduler.step()
+    return total_loss / max(1, len(loader))
+
+
+@torch.no_grad()
+def nnmil_val_loop(device, num_classes, model, loader, criterion, return_predictions=False, slide_paths=None):
+    model.eval()
+    total_loss, labels, probabilities, rows = 0.0, [], [], []
+    row_index = 0
+    for bags, target in loader:
+        bags, target = bags.to(device).float(), target.to(device).long()
+        mask = torch.ones(bags.shape[:2], device=device, dtype=torch.bool)
+        output = model(bags, valid_mask=mask)
+        logits = output["logits"]
+        total_loss += criterion(logits, target).item()
+        batch_probabilities = torch.softmax(logits, dim=-1).cpu()
+        probabilities.extend(batch_probabilities.tolist())
+        labels.extend(target.cpu().tolist())
+        if return_predictions:
+            for batch_index in range(bags.shape[0]):
+                row = {
+                    "slide_path": slide_paths[row_index] if slide_paths is not None else str(row_index),
+                    "label": int(target[batch_index].item()),
+                    "prediction": int(batch_probabilities[batch_index].argmax().item()),
+                    "total_entropy": float(output["total_entropy"][batch_index].item()),
+                    "aleatoric_entropy": float(output["aleatoric_entropy"][batch_index].item()),
+                    "mutual_information": float(output["mutual_information"][batch_index].item()),
+                    "num_subspaces": int(output["chunk_logits"].shape[0]),
+                }
+                for class_index, value in enumerate(batch_probabilities[batch_index].tolist()):
+                    row[f"probability_class_{class_index}"] = value
+                    row[f"probability_variance_class_{class_index}"] = float(
+                        output["probability_variance"][batch_index, class_index].item()
+                    )
+                rows.append(row)
+                row_index += 1
+    metrics = cal_scores(probabilities, labels, num_classes)
+    loss = total_loss / max(1, len(loader))
+    if return_predictions:
+        return loss, metrics, pd.DataFrame(rows)
+    return loss, metrics


### PR DESCRIPTION
## Summary

Adds the nnMIL classification workflow, including its fixed-length bag interface, random feature-subspace attention, and subspace-ensemble uncertainty estimates.

## Padding correctness

- Short bags are zero-padded only for batching and carry a valid-patch mask.
- Invalid positions are excluded from attention softmax, so padding cannot affect slide aggregation.
- Regression coverage verifies padded and unpadded bags produce the same prediction.

## Validation

- `python -m unittest tests.test_nn_mil -v` (5 tests, including a one-epoch train-to-inference smoke test)
- PR diff scanned for accidental credentials; no findings.